### PR TITLE
Prototype pollution (fixed)

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -119,6 +119,7 @@ function set(data, queryString, value, force) {
     }
 
     path.forEach((query, index) => {
+        if ('__proto__' === query || 'prototyped' === query || 'constructor' === query) return;
         if (isProperty.test(query) === false) {
             workingSet = select(workingSet, query);
             return;
@@ -141,6 +142,7 @@ function set(data, queryString, value, force) {
 
         } else {
             const unescapedProp = removeEscape(property);
+            if ('__proto__' === unescapedProp || 'prototyped' === unescapedProp || 'constructor' === unescapedProp) return;
             d[unescapedProp] = targetValue;
         }
     });


### PR DESCRIPTION
Hi,
This package is vulnerable to prototype pollution.
POC
```javascript
var gsonQuery = require("gson-query")
var obj = {}
console.log("Before : " + obj.polluted);
gsonQuery.set(obj,'__proto__/polluted','Yes! Its Polluted');
var obj1 ={}
console.log("After : " + obj1.polluted);
```
Added fix for this prototype pollution, 
Thank you.